### PR TITLE
Correct service names on dev compose

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -7,7 +7,7 @@ volumes:
 services:
   # The migration processor container - we'll use this as the base for the rest
   # of the app service definitions:
-  migration: &app
+  migrate: &app
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
- Rename 'migration' service to 'migrate'